### PR TITLE
Fixed bug with 'run test' where tests at bottom of file won't run.

### DIFF
--- a/python_test.py
+++ b/python_test.py
@@ -62,8 +62,10 @@ class RunPythonSeparateTestCommand(RunPythonTestCommand):
         test_path = super(RunPythonSeparateTestCommand, self).get_test_path()
         region = self.view.sel()[0]
         line_region = self.view.line(region)
+        file_character_start = 0
+        file_character_end = line_region.end()
         text_string = self.view.substr(
-            sublime.Region(region.begin() - 8000, line_region.end())
+            sublime.Region(file_character_start, file_character_end)
         )
         test_name = TestMethodMatcher().find_test_path(
             text_string, delimeter=self.test_delimeter

--- a/python_test.py
+++ b/python_test.py
@@ -63,9 +63,8 @@ class RunPythonSeparateTestCommand(RunPythonTestCommand):
         region = self.view.sel()[0]
         line_region = self.view.line(region)
         file_character_start = 0
-        file_character_end = line_region.end()
         text_string = self.view.substr(
-            sublime.Region(file_character_start, file_character_end)
+            sublime.Region(file_character_start, line_region.end())
         )
         test_name = TestMethodMatcher().find_test_path(
             text_string, delimeter=self.test_delimeter


### PR DESCRIPTION
The line of code starting with sublime.Region(... was hard-coding a region based on the current position minus 8000 characters. However in situations where the code file has much more than 8000 characters (say 400 lines of test code for example) tests towards the bottom of the file won't run because the resulting text_string will not contain the beginning of the class, which the code will try to find.
