### PR TITLE
Bug fix for find_test_class

### DIFF
--- a/python_test.py
+++ b/python_test.py
@@ -102,6 +102,6 @@ class TestMethodMatcher(object):
         match_classes = re.findall(r'\s?class\s+(\w+)\s?\(', test_file_content)
         if match_classes:
             try:
-                return [c for c in match_classes if "Test" in c or "test" in c][0]
+                return [c for c in match_classes if "Test" in c or "test" in c][-1]
             except IndexError:
                 return match_classes[-1]


### PR DESCRIPTION
We want the last match on the class list, not the first. The problem with the previous code is that if you have two test classes in the same file with different names, but the test methods have the same name, then when a single test is run, it would execute the first test found towards to top of the file, not the last test closest the cursor.
