### PR TITLE
Corrected the theme and syntax paths in PythonTestRunner.sublime-settings.

### DIFF
--- a/PythonTestRunner.sublime-settings
+++ b/PythonTestRunner.sublime-settings
@@ -1,4 +1,4 @@
 {
-  "theme": "Packages/Python Test Runner/PythonConsole.hidden-tmTheme",
-  "syntax": "Packages/Python Test Runner/PythonConsole.tmLanguage"
+  "theme": "Packages/PythonTestRunner/PythonConsole.hidden-tmTheme",
+  "syntax": "Packages/PythonTestRunner/PythonConsole.tmLanguage"
 }


### PR DESCRIPTION
I am not sure if this is really a bug, but my Sublime Text 2 had problems finding the Theme files. After changing this and restarting the editor everything is nice.
